### PR TITLE
change url for awesome_print gem location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "hashie"
 gem "sinatra", "1.4.4"
 gem "octokit", "~> 2.0"
-gem "awesome_print", git: "git@github.com:michaeldv/awesome_print.git"
+gem "awesome_print", git: "git@github.com:awesome-print/awesome_print.git"
 
 gem "pry", :group => "development"
 


### PR DESCRIPTION
The location for the 'awesome_print' gem changed to git@github.com:awesome-print/awesome_print.git, so the current solution no longer passes the tests. Updating the URL for the gem fixes this issue.